### PR TITLE
GLM-7158 - update deprecated follow endpoint

### DIFF
--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -396,7 +396,7 @@ module Twitch
       options[:from_id] = user_id
       options[:to_id] = channel_id
       query = build_query_string(options)
-      path = "/users/follows"
+      path = "/channels/followed"
       url = @base_url + path + query
 
       get(url)

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -393,8 +393,8 @@ module Twitch
     end
 
     def follow_status(user_id, channel_id, options = {})
-      options[:from_id] = user_id
-      options[:to_id] = channel_id
+      options[:user_id] = user_id
+      options[:broadcaster_id] = channel_id
       query = build_query_string(options)
       path = "/channels/followed"
       url = @base_url + path + query


### PR DESCRIPTION
## Change description

Belongs to the issue that was fixed in here: https://github.com/Crowd9/Gleam/pull/24202

However it is better to merge this change into a "base" branch (`api-helix`) than using these little branches on our main repo.
One additional reason is trying to solve a permission issue that we having, when trying to deploy.

## Type of change
- [X] Bug fix (fixes an issue)

## Related issues

> Fix [#1]() 
