### PR TITLE
Update HTTParty gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,25 +8,33 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    httparty (0.14.0)
+    bigdecimal (4.0.1)
+    csv (3.3.5)
+    diff-lcs (1.6.2)
+    httparty (0.24.0)
+      csv
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    json (2.0.3)
-    multi_xml (0.6.0)
-    rspec (3.0.0)
-      rspec-core (~> 3.0.0)
-      rspec-expectations (~> 3.0.0)
-      rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.3)
-      rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.3)
+    json (2.18.0)
+    mini_mime (1.1.5)
+    multi_xml (0.8.0)
+      bigdecimal (>= 3.1, < 5)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.3)
-      rspec-support (~> 3.0.0)
-    rspec-support (3.0.3)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.7)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.6)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
 
 DEPENDENCIES
@@ -34,4 +42,4 @@ DEPENDENCIES
   twitch!
 
 BUNDLED WITH
-   1.12.5
+   2.7.2


### PR DESCRIPTION
[GLM-14063](https://linear.app/gleamio/issue/GLM-14063)

Because of https://github.com/Crowd9/twitch-rb/security/dependabot/3 and https://github.com/Crowd9/twitch-rb/security/dependabot/1

The update to all the other gems were a necessary step to update the HTTParty gem